### PR TITLE
changes i would like

### DIFF
--- a/src/_components/_sections/DiscoverProgram/expectations.tsx
+++ b/src/_components/_sections/DiscoverProgram/expectations.tsx
@@ -1,9 +1,9 @@
 export default function Expectations() {
   return (
-    <section className="mb-16" id="expectations">
+    <section className="mb-8" id="expectations">
       <h2 className="text-3xl font-bold mb-8">
         <span className="relative">
-          <span className="relative z-10">Roles and Expectations</span>
+          <span className="relative z-10">Participant Expectations</span>
           <span
             className="absolute bottom-0 left-0 w-full"
             style={{

--- a/src/_components/_sections/DiscoverProgram/program-timeline.tsx
+++ b/src/_components/_sections/DiscoverProgram/program-timeline.tsx
@@ -1,11 +1,11 @@
 import { Calendar, UserCheck, CheckCircle } from "lucide-react";
 
-export default function ApplicationTimeline() {
+export default function ProgramTimeline() {
   return (
-    <section className="mb-16" id="application-timeline">
+    <section className="mb-16" id="program-timeline">
       <h2 className="text-3xl font-bold mb-8">
         <span className="relative">
-          <span className="relative z-10">Application Timeline</span>
+          <span className="relative z-10">Program Timeline</span>
           <span className="absolute bottom-0 left-0 w-full h-6 bg-green-200/20"></span>
         </span>
       </h2>

--- a/src/_components/_sections/DiscoverProgram/program-timeline.tsx
+++ b/src/_components/_sections/DiscoverProgram/program-timeline.tsx
@@ -10,7 +10,7 @@ export default function ProgramTimeline() {
         </span>
       </h2>
 
-      <p className="text-base text-gray-500 py-4 mb-8">
+      <p className="text-base text-gray-500 mb-8">
         Studios are <strong>mandatory, in-person, weekly</strong> meetings. They
         will be held every Monday from 7-8pm in Winter Quarter. The time for
         Studio during Spring Quarter will be announced later.
@@ -25,11 +25,12 @@ export default function ProgramTimeline() {
             First Studio & Client Prep
           </h3>
           <time className="block mb-3 text-sm font-normal leading-none text-gray-400">
-            Winter Quarter
+            Winter Quarter - Week 3
           </time>
           <p className="text-base text-gray-500">
-            First studio (fun program kickoff event), and prep for meeting
-            clients
+            The first studio will be a fun program kickoff event.
+            <br/>
+            Teams start preparing for their first client meetings.
           </p>
         </li>
 
@@ -43,7 +44,7 @@ export default function ProgramTimeline() {
           <time className="block mb-3 text-sm font-normal leading-none text-gray-400">
             Winter Quarter - Week 4
           </time>
-          <p className="text-base text-gray-500">First client meetings occur</p>
+          <p className="text-base text-gray-500">Teams meet with clients for the first time.</p>
         </li>
 
         <li className="mb-12 ms-6">
@@ -51,12 +52,12 @@ export default function ProgramTimeline() {
             <Calendar className="w-4 h-4 text-white" />
           </span>
           <h3 className="mb-2 text-lg font-semibold text-gray-900">
-            Winter Development
+            App Development
           </h3>
           <time className="block mb-3 text-sm font-normal leading-none text-gray-400">
             Winter Quarter - Weeks 5-9
           </time>
-          <p className="text-base text-gray-500">Work on projects</p>
+          <p className="text-base text-gray-500">Teams continuously work on projects.</p>
         </li>
 
         <li className="mb-12 ms-6">
@@ -70,7 +71,9 @@ export default function ProgramTimeline() {
             Winter Quarter - Week 10
           </time>
           <p className="text-base text-gray-500">
-            <strong>Winter Showcase</strong> (during studio)
+            An official midway checkpoint for teams to show off their progress.
+            <br/>
+            Held during extended studio time (normal studio time + one hour after).
           </p>
         </li>
 
@@ -79,12 +82,12 @@ export default function ProgramTimeline() {
             <Calendar className="w-4 h-4 text-white" />
           </span>
           <h3 className="mb-2 text-lg font-semibold text-gray-900">
-            Spring Development
+            App Development
           </h3>
           <time className="block mb-3 text-sm font-normal leading-none text-gray-400">
             Spring Quarter - Weeks 1-8
           </time>
-          <p className="text-base text-gray-500">Work on projects</p>
+          <p className="text-base text-gray-500">Teams continuously work on projects.</p>
         </li>
 
         <li className="ms-6">
@@ -98,7 +101,9 @@ export default function ProgramTimeline() {
             Spring Quarter - Week 9
           </time>
           <p className="text-base text-gray-500">
-            <strong>Final Project Showcase</strong> (during studio)
+            Teams present final projects to clients and the broader DISC community.
+            <br/>
+            Held during extended studio time (normal studio time + one hour after).
           </p>
         </li>
       </ol>

--- a/src/_components/_sections/DiscoverProgram/roles.tsx
+++ b/src/_components/_sections/DiscoverProgram/roles.tsx
@@ -1,4 +1,4 @@
-export default function TeamStructure() {
+export default function Roles() {
   return (
     <section className="mb-16" id="roles">
       <h2 className="text-3xl font-bold mb-8">

--- a/src/_components/_sections/DiscoverProgram/team-structure.tsx
+++ b/src/_components/_sections/DiscoverProgram/team-structure.tsx
@@ -4,7 +4,7 @@ export default function TeamStructure() {
       <h2 className="text-3xl font-bold mb-8">
         <span className="relative">
           <span className="relative z-10 text-black">
-            Team Structure and Layout
+            Roles
           </span>
           <span
             className="absolute bottom-0 left-0 w-full"

--- a/src/_components/_sections/DiscoverProgram/team-structure.tsx
+++ b/src/_components/_sections/DiscoverProgram/team-structure.tsx
@@ -1,6 +1,6 @@
 export default function TeamStructure() {
   return (
-    <section className="mb-16" id="team-structure">
+    <section className="mb-16" id="roles">
       <h2 className="text-3xl font-bold mb-8">
         <span className="relative">
           <span className="relative z-10 text-black">
@@ -17,6 +17,9 @@ export default function TeamStructure() {
       </h2>
 
       <div className="flex flex-col gap-6">
+        <p className="text-base leading-relaxed">
+          On each team, roles are divided as follows:
+        </p>
         <div className="p-4 bg-white rounded-lg shadow">
           <div className="flex items-start gap-3 text-base text-gray-500">
             <span className="text-2xl">👔</span>

--- a/src/_components/ui/section-navigation.tsx
+++ b/src/_components/ui/section-navigation.tsx
@@ -15,7 +15,7 @@ const SectionNavigation = () => {
       { id: "expectations", label: "Participant Expectations" },
       { id: "roles", label: "Roles" },
       { id: "project-descriptions", label: "Project Descriptions" },
-      { id: "application-timeline", label: "Application Timeline" },
+      { id: "program-timeline", label: "Program Timeline" },
       { id: "application-process", label: "Application Process" },
       { id: "faq", label: "FAQ" },
       { id: "cta", label: "Apply Now" },

--- a/src/_components/ui/section-navigation.tsx
+++ b/src/_components/ui/section-navigation.tsx
@@ -12,8 +12,8 @@ const SectionNavigation = () => {
     () => [
       { id: "program-overview", label: "Program Overview" },
       { id: "tech-stack", label: "Tech Stack" },
-      { id: "expectations", label: "Expectations" },
-      { id: "team-structure", label: "Team Structure" },
+      { id: "expectations", label: "Participant Expectations" },
+      { id: "roles", label: "Roles" },
       { id: "project-descriptions", label: "Project Descriptions" },
       { id: "application-timeline", label: "Application Timeline" },
       { id: "application-process", label: "Application Process" },

--- a/src/app/discover-program/page.tsx
+++ b/src/app/discover-program/page.tsx
@@ -3,9 +3,9 @@ import DiscoverProgramHero from "@/_components/_sections/DiscoverProgram/discove
 import ProgramOverview from "@/_components/_sections/DiscoverProgram/program-overview";
 import TechStack from "@/_components/_sections/DiscoverProgram/tech-stack";
 import Expectations from "@/_components/_sections/DiscoverProgram/expectations";
-import TeamStructure from "@/_components/_sections/DiscoverProgram/team-structure";
+import TeamStructure from "@/_components/_sections/DiscoverProgram/roles";
 import ProjectDescriptions from "@/_components/_sections/DiscoverProgram/project-descriptions";
-import ApplicationTimeline from "@/_components/_sections/DiscoverProgram/application-timeline";
+import ApplicationTimeline from "@/_components/_sections/DiscoverProgram/program-timeline";
 import ApplicationProcess from "@/_components/_sections/DiscoverProgram/application-process";
 import DiscoverFAQ from "@/_components/_sections/DiscoverProgram/discover-faq";
 import DiscoverCTA from "@/_components/_sections/DiscoverProgram/discover-cta";

--- a/src/app/discover-program/page.tsx
+++ b/src/app/discover-program/page.tsx
@@ -4,7 +4,6 @@ import ProgramOverview from "@/_components/_sections/DiscoverProgram/program-ove
 import TechStack from "@/_components/_sections/DiscoverProgram/tech-stack";
 import Expectations from "@/_components/_sections/DiscoverProgram/expectations";
 import TeamStructure from "@/_components/_sections/DiscoverProgram/team-structure";
-import ExpectationsSummary from "@/_components/_sections/DiscoverProgram/expectations-summary";
 import ProjectDescriptions from "@/_components/_sections/DiscoverProgram/project-descriptions";
 import ApplicationTimeline from "@/_components/_sections/DiscoverProgram/application-timeline";
 import ApplicationProcess from "@/_components/_sections/DiscoverProgram/application-process";
@@ -21,7 +20,6 @@ export default function DiscoverProgramPage() {
         <ProgramOverview />
         <TechStack />
         <Expectations />
-        <TeamStructure />
         <WarningAlert
           title="Important Notice"
           message="Participants who are not fulfilling expectations are subject to
@@ -29,7 +27,7 @@ export default function DiscoverProgramPage() {
             applicant waitlist will be maintained to reduce the impact of these
             potential removals on the teams and projects"
         />
-        <ExpectationsSummary />
+        <TeamStructure />
         <ProjectDescriptions />
         <ApplicationTimeline />
         <ApplicationProcess />


### PR DESCRIPTION
1. rename "roles and expectations" section to "participant expectations" since the roles info is in a different section now
2. rename "team structure and layout" to "roles"
3. move the warning about getting booted to after `participant expectations` instead of after `roles`, since it's most relevant to `participant expectations`. as in, people will get booted for not fulfilling participant expectations, but they wont really get booted for not fulling role expectations since those are much more loosely defined. 
4. we can also remove the participant summary since it's no longer needed, given this reorg^
5. rename "application timeline" to "program timeline" for accuracy
6. added better descriptions of each item in the timeline
7. fix spacing under program timeline